### PR TITLE
Api url is parameter now + new tests

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -6,7 +6,7 @@
 #' @export
 get_datasets <- function(project_hid) {
   #' Gets list of available datasets
-  api_url_datasets <- paste("https://mljar.com/api/", API_VERSION, "/datasets?project_id=", project_hid, sep = "")
+  api_url_datasets <- paste(MLAR_API_PATH, API_VERSION, "/datasets?project_id=", project_hid, sep = "")
   rp <- .get_json_from_get_query(api_url_datasets)
   resp <- rp$resp
   parsed <- rp$parsed
@@ -32,7 +32,7 @@ print.get_datasets <- function(x, ...) {
 #' @return structure with parsed dataset and response
 #' @export
 get_dataset <- function(dataset_hid) {
-  api_url_dataset_hid <- paste("https://mljar.com/api/", API_VERSION, "/datasets/", dataset_hid, sep="")
+  api_url_dataset_hid <- paste(MLAR_API_PATH, API_VERSION, "/datasets/", dataset_hid, sep="")
   rp <- .get_json_from_get_query(api_url_dataset_hid)
   resp <- rp$resp
   parsed <- rp$parsed
@@ -57,7 +57,7 @@ print.get_dataset <- function(x, ...) {
 #' @export
 delete_dataset <-function(dataset_hid){
   token <- .get_token()
-  api_url_dataset_hid <- paste("https://mljar.com/api/", API_VERSION, "/datasets/", dataset_hid, sep="")
+  api_url_dataset_hid <- paste(MLAR_API_PATH, API_VERSION, "/datasets/", dataset_hid, sep="")
   resp <- DELETE(api_url_dataset_hid, add_headers(Authorization = paste("Token", token)))
   if (status_code(resp)==204 || status_code(resp)==200){
     sprintf("Dataset <%s> succesfully deleted!", dataset_hid)
@@ -82,7 +82,7 @@ add_new_dataset <- function(project_hid, filename, title, prediction_only=FALSE)
   prediction_only <- as.integer(prediction_only)
 
   token <- .get_token()
-  api_url_new_dataset <- paste("https://mljar.com/api/", API_VERSION, "/datasets" , sep="")
+  api_url_new_dataset <- paste(MLAR_API_PATH, API_VERSION, "/datasets" , sep="")
   data <- list(
     title = title,
     file_path = dst_path,
@@ -150,7 +150,7 @@ add_new_dataset <- function(project_hid, filename, title, prediction_only=FALSE)
 #'
 .accept_dataset_column_usage <- function(dataset_hid){
   token <- .get_token()
-  api_url_new_dataset <- paste("https://mljar.com/api/", API_VERSION, "/accept_column_usage/" , sep="")
+  api_url_new_dataset <- paste(MLAR_API_PATH, API_VERSION, "/accept_column_usage/" , sep="")
   data <- list(dataset_id = dataset_hid)
   resp <- POST(api_url_new_dataset, add_headers(Authorization = paste("Token", token)),
                body = data, encode = "form")

--- a/R/dataupload.R
+++ b/R/dataupload.R
@@ -29,7 +29,7 @@ upload_file <- function(project_hid, filepath){
 #'
 #' @return parsed htt response from MLJAR s3policy (check mljar api for more)
 .get_signed_url <- function(project_hid, filepath){
-  api_url_signed_url <- paste("https://mljar.com/api/", API_VERSION, "/s3policy/" , sep="")
+  api_url_signed_url <- paste(MLAR_API_PATH, API_VERSION, "/s3policy/" , sep="")
   fname = tail(strsplit(filepath, "/")[[1]], n=1)
   data <- list(project_hid = project_hid,
                fname = fname)

--- a/R/experiment.R
+++ b/R/experiment.R
@@ -5,7 +5,7 @@
 #' @return  structure with parsed experiments and http response
 #' @export
 get_experiments <- function(project_hid){
-  api_url_experiments <- paste("https://mljar.com/api/", API_VERSION, "/experiments",
+  api_url_experiments <- paste(MLAR_API_PATH, API_VERSION, "/experiments",
                                "?project_id=", project_hid, sep="")
   rp <- .get_json_from_get_query(api_url_experiments)
   resp <- rp$resp
@@ -33,7 +33,7 @@ print.get_experiments <- function(x, ...) {
 #' @return structure with parsed experiment and http response
 #' @export
 get_experiment <- function(experiment_hid){
-  api_url_experiment <- paste("https://mljar.com/api/", API_VERSION, "/experiments/",
+  api_url_experiment <- paste(MLAR_API_PATH, API_VERSION, "/experiments/",
                                experiment_hid, sep="")
   rp <- .get_json_from_get_query(api_url_experiment)
   resp <- rp$resp
@@ -65,7 +65,7 @@ print.get_experiment <- function(x, ...) {
 #' @importFrom jsonlite fromJSON
 create_experiment <- function(data){
   token <- .get_token()
-  api_url_create_experiment <- paste("https://mljar.com/api/", API_VERSION, "/experiments" , sep="")
+  api_url_create_experiment <- paste(MLAR_API_PATH, API_VERSION, "/experiments" , sep="")
   resp <- POST(api_url_create_experiment, add_headers(Authorization = paste("Token", token)),
                body = data, encode = "form")
   .check_response_status(resp, 201)

--- a/R/params.R
+++ b/R/params.R
@@ -1,7 +1,8 @@
 # MLJAR Constants
 #################
 
-API_VERSION <- "v1"
+MLAR_API_PATH <- "https://mljar.com/api/"
+API_VERSION   <- "v1"
 
 MLJAR_TASKS <- list( bin_class = 'Binary Classification',
                      regression = 'Regression'

--- a/R/prediction.R
+++ b/R/prediction.R
@@ -7,7 +7,7 @@
 #' @return structure with parsed prediction and http response
 #' @export
 get_prediction <- function(project_hid, dataset_hid, result_hid){
-  api_url_prediction <- paste("https://mljar.com/api/", API_VERSION, "/predictions",
+  api_url_prediction <- paste(MLAR_API_PATH, API_VERSION, "/predictions",
                                "?project_id=", project_hid, "&dataset_id=",
                                dataset_hid, "&result_id=", result_hid, sep="")
   rp <- .get_json_from_get_query(api_url_prediction)

--- a/R/prediction_download.R
+++ b/R/prediction_download.R
@@ -9,7 +9,7 @@
 #' @export
 prediction_download <- function(prediction_hid){
   token <- .get_token()
-  api_url_preddown <- paste("https://mljar.com/api/", API_VERSION, "/download/prediction/" , sep="")
+  api_url_preddown <- paste(MLAR_API_PATH, API_VERSION, "/download/prediction/" , sep="")
   data <- list( prediction_id =  prediction_hid)
   resp <- POST(api_url_preddown, add_headers(Authorization = paste("Token", token)),
                body = data, encode = "form")

--- a/R/predictjob.R
+++ b/R/predictjob.R
@@ -16,7 +16,7 @@ submit_predict_job <- function(project_hid, dataset_hid, result_hid){
                                             cv_models = 1),
                                        auto_unbox =TRUE)
               )
-  query <- paste("https://mljar.com/api/", API_VERSION, "/predict/" , sep="")
+  query <- paste(MLAR_API_PATH, API_VERSION, "/predict/" , sep="")
   resp <- POST(query, add_headers(Authorization = paste("Token", token)),
                body = data, encode = "form")
   .check_response_status(resp, 200, "Predict MLJAR job failed")

--- a/R/projects.R
+++ b/R/projects.R
@@ -5,7 +5,7 @@
 #' @return structure with parsed projects and http response
 #' @export
 get_projects <- function() {
-  api_url_projects <- paste("https://mljar.com/api/", API_VERSION, "/projects" , sep="")
+  api_url_projects <- paste(MLAR_API_PATH, API_VERSION, "/projects" , sep="")
   rp <- .get_json_from_get_query(api_url_projects)
   resp <- rp$resp
   parsed <- rp$parsed
@@ -33,7 +33,7 @@ print.get_projects <- function(x, ...) {
 #' @return structure with parsed project and http response
 #' @export
 get_project <- function(hid) {
-  api_url_project_hid <- paste("https://mljar.com/api/", API_VERSION, "/projects/", hid, sep="")
+  api_url_project_hid <- paste(MLAR_API_PATH, API_VERSION, "/projects/", hid, sep="")
   rp <- .get_json_from_get_query(api_url_project_hid)
   resp <- rp$resp
   parsed <- rp$parsed
@@ -64,7 +64,7 @@ print.get_project <- function(x, ...) {
 create_project <-function(title, task, description=""){
   .verify_if_project_exists(title, task)
   token <- .get_token()
-  api_url_projects <- paste("https://mljar.com/api/", API_VERSION, "/projects" , sep="")
+  api_url_projects <- paste(MLAR_API_PATH, API_VERSION, "/projects" , sep="")
   data <- list(title = title,
                hardware = 'cloud',
                scope = 'private',
@@ -89,7 +89,7 @@ create_project <-function(title, task, description=""){
 #' @importFrom httr DELETE status_code
 delete_project <-function(hid){
   token <- .get_token()
-  api_url_project_hid <- paste("https://mljar.com/api/", API_VERSION, "/projects/", hid, sep="")
+  api_url_project_hid <- paste(MLAR_API_PATH, API_VERSION, "/projects/", hid, sep="")
   resp <- DELETE(api_url_project_hid, add_headers(Authorization = paste("Token", token)))
   if (status_code(resp)==204 || status_code(resp)==200){
     print(sprintf("Project <%s> succesfully deleted!", hid))

--- a/R/result.R
+++ b/R/result.R
@@ -10,7 +10,7 @@
 #' @export
 get_results <- function(project_hid, experiment_hid){
   token <- .get_token()
-  api_url_results <- paste("https://mljar.com/api/", API_VERSION, "/results/" , sep="")
+  api_url_results <- paste(MLAR_API_PATH, API_VERSION, "/results/" , sep="")
   datares <- list( project_id =  project_hid,
                    experiment_id =  experiment_hid)
   resp <- POST(api_url_results, add_headers(Authorization = paste("Token", token)),

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -12,20 +12,6 @@ y.tr <- irisdata2[1:80,5]
 x.vl <- irisdata2[81:100,-5]
 y.vl <- irisdata2[81:100,5]
 
-test_that("test .obtain_task", {
-  expect_equal(.obtain_task(c(1,0,0,0)), "bin_class")
-  expect_equal(.obtain_task(c(1,2,3)), "reg")
-})
-
-test_that("test .data_check", {
-  expect_error(.data_check(c(1,2,3), data.frame(a=c(1,2), b=c(2,1))),
-               "Sorry, multiple outputs are not supported in MLJAR")
-  expect_error(.data_check(as.data.frame(c(1,2,3)), data.frame(a=c(1,2))),
-               "Sorry, there is a missmatch between X and y matrices shapes")
-  expect_error(.data_check(as.data.frame(c(1,2)), data.frame(a=c(1,2))),
-               NA)
-})
-
 test_that("test mljar_fit reactions to bad arguments",{
   expect_error(mljar_fit(x.tr, y.tr, validx=NULL, validy=NULL,
                          proj_title="fullproject1", exp_title="fullexp1",

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,0 +1,40 @@
+library(mljar)
+context("Test utils")
+
+test_that("test .get_token", {
+  tok <- .get_token()
+  expect_type(tok, "character")
+})
+
+test_that("test .get_json_from_get_query", {
+  query <- paste0("https://mljar.com/api/", API_VERSION, "/projects")
+  r <- .get_json_from_get_query(query)
+  expect_equal(names(r), c("resp", "parsed"))
+})
+
+test_that("test .check_response_status", {
+  query <- paste0("https://mljar.com/api/", API_VERSION, "/projects")
+  r <- .get_json_from_get_query(query)
+  expect_error(.check_response_status(r$resp, 200), NA)
+  expect_error(.check_response_status(r$resp, 222, "omg"), "omg")
+})
+
+test_that("test .obtain_task", {
+  expect_equal(.obtain_task(c(1,0,0,0)), "bin_class")
+  expect_equal(.obtain_task(c(1,2,3)), "reg")
+})
+
+test_that("test .data_check", {
+  expect_error(.data_check(c(1,2,3), data.frame(a=c(1,2), b=c(2,1))),
+               "Sorry, multiple outputs are not supported in MLJAR")
+  expect_error(.data_check(as.data.frame(c(1,2,3)), data.frame(a=c(1,2))),
+               "Sorry, there is a missmatch between X and y matrices shapes")
+  expect_error(.data_check(as.data.frame(c(1,2)), data.frame(a=c(1,2))),
+               NA)
+})
+
+test_that("test .data_to_file", {
+  tmpf <- .data_to_file(c(1,2))
+  expect_type(tmpf, "character")
+  expect_equal(unlist(strsplit(tmpf,"[.]"))[[2]], "csv")
+})


### PR DESCRIPTION
Two changes introduced in this PR:
- as requested mljar api url is now parameter specified in `params.R`;
- new unittests added, so that coverage is now > 90% 